### PR TITLE
Add ppm limiter

### DIFF
--- a/limiters.py
+++ b/limiters.py
@@ -4,7 +4,7 @@ from functions import fv
 
 ##############################################################################
 
-from reconstruct import xppm
+from reconstruct import xppm, modified
 
 # Apply limiters based on the reconstruction method
 def applyLimiter(extrapolatedValues, solver):
@@ -17,7 +17,10 @@ def applyLimiter(extrapolatedValues, solver):
             wF_limit_R = faceValueLimiter(wFR, w[:-2], wS, w[2:], w2[4:])
             return [wF_limit_L, wF_limit_R]
         else:
-            return faceValueLimiter(wF, w[:-2], wS, w[2:], w2[4:])
+            if modified:
+                return wF
+            else:
+                return faceValueLimiter(wF, w[:-2], wS, w[2:], w2[4:])
 
     # Apply the minmod limiter
     elif solver in ["plm", "linear", "l"]:

--- a/reconstruct.py
+++ b/reconstruct.py
@@ -5,6 +5,7 @@ from functions import fv
 ##############################################################################
 
 xppm = 0
+modified = 1
 
 # Extrapolate the cell averages to face averages
 def extrapolate(tube, gamma, solver, boundary):
@@ -39,11 +40,12 @@ def extrapolate(tube, gamma, solver, boundary):
                 #wF = 1/60 * (37*(wS+w[2:]) - 8*(w[:-2]+w2[4:]) + (w2[:-4]+w3[6:]))
 
                 # Modified stencil [McCorquodale & Colella, 2011, eq. 21-22]
-                wF[0] = 1/12 * (25*wS[1] - 23*wS[2] + 13*wS[3] - 3*wS[4])
-                wF[-1] = 1/12 * (25*wS[-1] - 23*wS[-2] + 13*wS[-3] - 3*wS[-4])
+                if modified:
+                    wF[0] = 1/12 * (25*wS[1] - 23*wS[2] + 13*wS[3] - 3*wS[4])
+                    wF[-1] = 1/12 * (25*wS[-1] - 23*wS[-2] + 13*wS[-3] - 3*wS[-4])
 
-                wF[1] = 1/12 * (3*wS[1] + 13*wS[2] - 5*wS[3] + wS[4])
-                wF[-2] = 1/12 * (3*wS[-1] + 13*wS[-2] - 5*wS[-3] + wS[-4])
+                    wF[1] = 1/12 * (3*wS[1] + 13*wS[2] - 5*wS[3] + wS[4])
+                    wF[-2] = 1/12 * (3*wS[-1] + 13*wS[-2] - 5*wS[-3] + wS[-4])
                 return [wS, wF, w, w2]
         else:
             return w
@@ -95,55 +97,119 @@ def interpolate(extrapolatedValues, limitedValues, solver, boundary):
             else:
                 return [wF_limit_L, wF_limit_R]
 
-        # Limited parabolic interpolant [Colella et al., 2011, p. 26]
         else:
-            wF_limit = fv.makeBoundary(limitedValues, boundary)
-            wF_limit_2 = fv.makeBoundary(limitedValues, boundary, 2)
+            # Limited modified parabolic interpolant [McCorquodale & Colella, 2011]
+            if modified:
+                C3 = .1
+                wF_limit = fv.makeBoundary(limitedValues, boundary)
+                wF_limit_2 = fv.makeBoundary(limitedValues, boundary, 2)
+                wF_limit_3 = fv.makeBoundary(limitedValues, boundary, 3)
 
-            wF_limit_L, wF_limit_R = wF_limit[:-2], limitedValues
+                wF_limit_L, wF_limit_R = wF_limit[:-2], limitedValues
 
-            # Check for cell extrema in cells (eq. 89)
-            d_uL, d_uR = wS - wF_limit_L, wF_limit_R - wS
-            cell_extrema = d_uL*d_uR < 0
+                # Set differences
+                dw_minus, dw_plus = wS - wF_limit_L, wF_limit_R - wS
+                d2w = 6 * (wF_limit_L - 2*wS + wF_limit_R)
+                d2w_C = w[:-2] - 2*wS + w[2:]
 
-            # Check for overshoot in cells (eq. 90)
-            overshoot = (np.abs(d_uL) > 2*np.abs(d_uR)) | (np.abs(d_uR) > 2*np.abs(d_uL))
+                # Approximation to the third derivative (eq. 23)
+                d3w = np.diff(fv.makeBoundary(d2w_C, boundary), axis=0)[1:]
 
-            # Check for extrema in interpolants (eq. 91-94)
-            d_wF_minmod = np.minimum(np.abs(wF_limit_L - wF_limit_2[:-4]), np.abs(wF_limit_2[4:] - wF_limit_R))
-            d_wS_minmod = np.minimum(np.abs(wS - w[:-2]), np.abs(w[2:] - wS))
-            interpolant_extrema = ((d_wF_minmod >= d_wS_minmod) & ((wF_limit_L - wF_limit_2[:-4])*(wF_limit_2[4:] - wF_limit_R) < 0)) | ((d_wS_minmod >= d_wF_minmod) & ((wS - w[:-2])*(w[2:] - wS) < 0))
+                # Check for cell extreme in cells (eq. 24-25)
+                cell_extrema = (dw_minus*dw_plus <= 0) | ((wS-w2[:-4])*(w2[4:]-wS) <= 0)
 
-            # If there are extrema in either the cells or interpolants
-            if cell_extrema.any() or interpolant_extrema.any():
-                D2w_lim = np.zeros(wS.shape)
+                # If there are extrema in the cells
+                if cell_extrema.any():
+                    d2w_Cw = fv.makeBoundary(d2w_C, boundary)
+                    d2w_lim = np.zeros(wS.shape)
 
-                # Approximation to the second derivative (eq. 95)
-                D2w = 6 * (wF_limit_L - 2*wS + wF_limit_R)
-                D2w_L = w2[:-4] - 2*w[:-2] + wS
-                D2w_C = w[:-2] - 2*wS + w[2:]
-                D2w_R = wS - 2*w[2:] + w2[4:]
+                    # Get the curvatures that have the same signs
+                    non_monotonic = (np.sign(d2w_Cw[:-2]) == np.sign(d2w_Cw[2:])) & (np.sign(d2w) == np.sign(d2w_C)) & (np.sign(d2w_C) == np.sign(d2w_Cw[:-2])) & (np.sign(d2w_C) == np.sign(d2w_Cw[2:])) & (np.sign(d2w) == np.sign(d2w_Cw[:-2])) & (np.sign(d2w) == np.sign(d2w_Cw[2:]))
+                    # Determine the limited curvature with the sign of each element in the 'main' array (eq. 26)
+                    limited_curvature = np.sign(d2w_C) * np.minimum(np.minimum(np.abs(d2w), C*np.abs(d2w_C)), np.minimum(C*np.abs(d2w_Cw[2:]), C*np.abs(d2w_Cw[:-2])))
+                    # Update the limited local curvature estimates based on the conditions
+                    d2w_lim[cell_extrema] = limited_curvature[cell_extrema]
 
-                # Get the curvatures that have the same signs
-                non_monotonic = (np.sign(D2w_L) == np.sign(D2w_R)) & (np.sign(D2w_C) == np.sign(D2w)) & (np.sign(D2w_C) == np.sign(D2w_R))
+                    # Determine the limited values that are sensitive to roundoff errors
+                    rho_limiter = np.zeros(wS.shape)
+                    # Get the cells where the limited values fulfil the condition
+                    sensitive = np.abs(d2w) > 1e-12 * np.maximum(np.abs(wS), np.maximum(np.maximum(np.abs(w[:-2]), np.abs(w[2:])), np.maximum(np.abs(w2[:-4]), np.abs(w2[4:]))))
+                    # Update the limited estimates based on the condition (eq. 27)
+                    d2w[d2w == 0] = np.inf
+                    rho_limiter[sensitive] = (d2w_lim/d2w)[sensitive]
 
-                # Determine the limited curvature with the sign of each element in the 'main' array (eq. 96)
-                limited_curvature = np.sign(D2w) * np.minimum(np.minimum(np.abs(D2w), np.abs(C*D2w_C)), np.minimum(np.abs(C*D2w_L), np.abs(C*D2w_R)))
+                    # Apply additional limiters
+                    d3w_w = fv.makeBoundary(d3w, boundary)
+                    d3w_w2 = fv.makeBoundary(d3w, boundary, 2)
+                    d3w_min = np.minimum(np.minimum(d3w_w[:-2], d3w), np.minimum(d3w_w2[:-4], d3w_w2[4:]))
+                    d3w_max = np.maximum(np.maximum(d3w_w[:-2], d3w), np.maximum(d3w_w2[:-4], d3w_w2[4:]))
 
-                # Update the limited local curvature estimates based on the conditions
-                D2w_lim[cell_extrema & non_monotonic] = limited_curvature[cell_extrema & non_monotonic]
-                D2w_lim[interpolant_extrema & non_monotonic] = limited_curvature[interpolant_extrema & non_monotonic]
+                    # (eq. 28)
+                    roundoff_limiters = (rho_limiter < (1-1e-12)) | (C3*np.maximum(np.abs(d3w_max), np.abs(d3w_min)) <= (d3w_max-d3w_min))
 
-                D2w[D2w == 0] = np.inf  # removes divide-by-zero error; causes wFL & wFR -> wS (i.e. piecewise constant) when D2w = 0
+                    # (eq. 29-30)
+                    wF_limit_L[(dw_minus*dw_plus < 0) & (roundoff_limiters)] = (wS - rho_limiter*dw_minus)[(dw_minus*dw_plus < 0) & (roundoff_limiters)]
+                    wF_limit_R[(dw_minus*dw_plus < 0) & (roundoff_limiters)] = (wS + rho_limiter*dw_plus)[(dw_minus*dw_plus < 0) & (roundoff_limiters)]
 
-                # Further update if there is local extrema (eq. 97-98)
-                d_uL_bar, d_uR_bar = np.copy(d_uL), np.copy(d_uR)
-                if overshoot.any():
-                    d_uL_bar[np.abs(d_uL) > 2*np.abs(d_uR)] = 2*d_uR[np.abs(d_uL) > 2*np.abs(d_uR)]
-                    d_uR_bar[np.abs(d_uR) > 2*np.abs(d_uL)] = 2*d_uL[np.abs(d_uR) > 2*np.abs(d_uL)]
-                return [wS - d_uL_bar*(D2w_lim/D2w), wS + d_uR_bar*(D2w_lim/D2w)]  # (eq. 98)
-            else:
+                    # (eq. 31-32)
+                    wF_limit_L[(roundoff_limiters) & (np.abs(dw_minus) >= 2*np.abs(dw_plus))] = (wS - 2*(1-rho_limiter)*dw_plus - rho_limiter*dw_minus)[(roundoff_limiters) & (np.abs(dw_minus) >= 2*np.abs(dw_plus))]
+                    wF_limit_R[(roundoff_limiters) & (np.abs(dw_plus) >= 2*np.abs(dw_minus))] = (wS + 2*(1-rho_limiter)*dw_minus + rho_limiter*dw_plus)[(roundoff_limiters) & (np.abs(dw_plus) >= 2*np.abs(dw_minus))]
+                else:
+                    wF_limit_L[np.abs(dw_minus) >= 2*np.abs(dw_plus)] = (wS - 2*dw_plus)[np.abs(dw_minus) >= 2*np.abs(dw_plus)]
+                    wF_limit_R[np.abs(dw_plus) >= 2*np.abs(dw_minus)] = (wS + 2*dw_minus)[np.abs(dw_plus) >= 2*np.abs(dw_minus)]
+
                 return [wF_limit_L, wF_limit_R]
+
+
+            # Limited parabolic interpolant [Colella et al., 2011, p. 26]
+            else:
+                wF_limit = fv.makeBoundary(limitedValues, boundary)
+                wF_limit_2 = fv.makeBoundary(limitedValues, boundary, 2)
+
+                wF_limit_L, wF_limit_R = wF_limit[:-2], limitedValues
+
+                # Check for cell extrema in cells (eq. 89)
+                d_uL, d_uR = wS - wF_limit_L, wF_limit_R - wS
+                cell_extrema = d_uL*d_uR < 0
+
+                # Check for overshoot in cells (eq. 90)
+                overshoot = (np.abs(d_uL) > 2*np.abs(d_uR)) | (np.abs(d_uR) > 2*np.abs(d_uL))
+
+                # Check for extrema in interpolants (eq. 91-94)
+                d_wF_minmod = np.minimum(np.abs(wF_limit_L - wF_limit_2[:-4]), np.abs(wF_limit_2[4:] - wF_limit_R))
+                d_wS_minmod = np.minimum(np.abs(wS - w[:-2]), np.abs(w[2:] - wS))
+                interpolant_extrema = ((d_wF_minmod >= d_wS_minmod) & ((wF_limit_L - wF_limit_2[:-4])*(wF_limit_2[4:] - wF_limit_R) < 0)) | ((d_wS_minmod >= d_wF_minmod) & ((wS - w[:-2])*(w[2:] - wS) < 0))
+
+                # If there are extrema in either the cells or interpolants
+                if cell_extrema.any() or interpolant_extrema.any():
+                    D2w_lim = np.zeros(wS.shape)
+
+                    # Approximation to the second derivative (eq. 95)
+                    D2w = 6 * (wF_limit_L - 2*wS + wF_limit_R)
+                    D2w_L = w2[:-4] - 2*w[:-2] + wS
+                    D2w_C = w[:-2] - 2*wS + w[2:]
+                    D2w_R = wS - 2*w[2:] + w2[4:]
+
+                    # Get the curvatures that have the same signs
+                    non_monotonic = (np.sign(D2w_L) == np.sign(D2w_R)) & (np.sign(D2w_C) == np.sign(D2w)) & (np.sign(D2w_C) == np.sign(D2w_R))
+
+                    # Determine the limited curvature with the sign of each element in the 'main' array (eq. 96)
+                    limited_curvature = np.sign(D2w) * np.minimum(np.minimum(np.abs(D2w), np.abs(C*D2w_C)), np.minimum(np.abs(C*D2w_L), np.abs(C*D2w_R)))
+
+                    # Update the limited local curvature estimates based on the conditions
+                    D2w_lim[cell_extrema & non_monotonic] = limited_curvature[cell_extrema & non_monotonic]
+                    D2w_lim[interpolant_extrema & non_monotonic] = limited_curvature[interpolant_extrema & non_monotonic]
+
+                    D2w[D2w == 0] = np.inf  # removes divide-by-zero error; causes wFL & wFR -> wS (i.e. piecewise constant) when D2w = 0
+
+                    # Further update if there is local extrema (eq. 97-98)
+                    d_uL_bar, d_uR_bar = np.copy(d_uL), np.copy(d_uR)
+                    if overshoot.any():
+                        d_uL_bar[np.abs(d_uL) > 2*np.abs(d_uR)] = 2*d_uR[np.abs(d_uL) > 2*np.abs(d_uR)]
+                        d_uR_bar[np.abs(d_uR) > 2*np.abs(d_uL)] = 2*d_uL[np.abs(d_uR) > 2*np.abs(d_uL)]
+                    return [wS - d_uL_bar*(D2w_lim/D2w), wS + d_uR_bar*(D2w_lim/D2w)]  # (eq. 98)
+                else:
+                    return [wF_limit_L, wF_limit_R]
 
     # Linear reconstruction [Derigs et al., 2017]
     elif solver in ["plm", "linear", "l"]:


### PR DESCRIPTION
Added the PPM limiter from McCorquodale & Colella, 2011. This limiter seems to be the least diffusive in the smooth tests (Gaussian, sin-wave), but there are a lot of oscillations at strong shocks. A slope flattener still needs to be implemented into the code.