### PR TITLE
Edit infrastructure

### DIFF
--- a/functions/analytic.py
+++ b/functions/analytic.py
@@ -22,7 +22,7 @@ def calculate_entropy_density(grid, gamma):
 
 # Function for solution error calculation of sin-wave and Gaussian tests
 def calculate_solution_error(simulation, sim_variables, norm):
-    config, dimension = sim_variables.config, sim_variables.dimension
+    dimension = sim_variables.dimension
 
     time_keys = [float(t) for t in simulation.keys()]
     w_num = simulation[str(max(time_keys))]  # Get last instance of the grid with largest time key
@@ -46,6 +46,7 @@ def calculate_solution_error(simulation, sim_variables, norm):
 # Function for calculation of total variation (TVD scheme if TV(t+1) < TV(t)); total variation tests for oscillations
 def calculate_tv(simulation, sim_variables):
     dimension, tv = sim_variables.dimension, {}
+
     for t in list(simulation.keys()):
         grid = simulation[t]
         thermal = fv.divide(grid[...,4], grid[...,0])

--- a/numerics/solvers.py
+++ b/numerics/solvers.py
@@ -273,8 +273,8 @@ def calculate_DOTS_flux(qLs, qRs, fLs, fRs, sim_variables):
     jacobian = np.sum((weights*abs_A.T).T, axis=0)
 
     # Compute the Osher-Solomon dissipation term
-    _qLs = jacobian @ qLs[..., np.newaxis]
-    _qRs = jacobian @ qRs[..., np.newaxis]
+    _qLs = jacobian @ qLs[...,None]
+    _qRs = jacobian @ qRs[...,None]
     _qLs = _qLs.reshape(len(_qLs), len(_qLs[0]))
     _qRs = _qRs.reshape(len(_qRs), len(_qRs[0]))
 
@@ -385,7 +385,7 @@ def calculate_ES_flux(wLs, wRs, sim_variables):
 
     # Calculate the dissipation term
     abs_A = right_eigenvectors @ eigenvalues @ right_eigenvectors.transpose(0,2,1)
-    _dissipation = abs_A @ entropy_vector[..., np.newaxis]
+    _dissipation = abs_A @ entropy_vector[...,None]
     dissipation = _dissipation.reshape(len(entropy_vector), len(entropy_vector[0]))
 
     return ec_flux + .5*dissipation

--- a/schemes/pcm.py
+++ b/schemes/pcm.py
@@ -21,7 +21,7 @@ def run(grid, sim_variables):
 
         # Compute the fluxes and the Jacobian
         w = fv.add_boundary(wS, boundary)
-        f = constructors.make_flux_term(w, gamma, axis)
+        f = constructors.make_flux(w, gamma, axis)
         A = constructors.make_Jacobian(w, gamma, axis)
 
         # Update dict

--- a/schemes/plm.py
+++ b/schemes/plm.py
@@ -42,7 +42,7 @@ def run(grid, sim_variables):
         qLs, qRs = fv.convert_primitive(wLs, sim_variables, "face"), fv.convert_primitive(wRs, sim_variables, "face")
 
         # Compute the fluxes and the Jacobian
-        fLs, fRs = constructors.make_flux_term(wLs, gamma, axis), constructors.make_flux_term(wRs, gamma, axis)
+        fLs, fRs = constructors.make_flux(wLs, gamma, axis), constructors.make_flux(wRs, gamma, axis)
         A = constructors.make_Jacobian(w, gamma, axis)
 
         # Update dict

--- a/schemes/ppm.py
+++ b/schemes/ppm.py
@@ -83,7 +83,7 @@ def run(grid, sim_variables, paper="mc", dissipate=False):
 
         # Compute the fluxes and the Jacobian
         _w = fv.add_boundary(boundary_avg, boundary)
-        fLs, fRs = constructors.make_flux_term(wLs, gamma, axis), constructors.make_flux_term(wRs, gamma, axis)
+        fLs, fRs = constructors.make_flux(wLs, gamma, axis), constructors.make_flux(wRs, gamma, axis)
 
         if (paper == "mc" or "mccorquodale" in paper) and dissipate:
             data[axes]['mu'] = apply_artificial_viscosity(wS, axis, sim_variables)

--- a/schemes/weno.py
+++ b/schemes/weno.py
@@ -173,7 +173,7 @@ def run(grid, sim_variables):
 
         # Compute the fluxes and the Jacobian
         _w = fv.add_boundary(boundary_avg, boundary)
-        fLs, fRs = constructors.make_flux_term(wLs, gamma, axis), constructors.make_flux_term(wRs, gamma, axis)
+        fLs, fRs = constructors.make_flux(wLs, gamma, axis), constructors.make_flux(wRs, gamma, axis)
         A = constructors.make_Jacobian(_w, gamma, axis)
 
         # Update dict


### PR DESCRIPTION
Attempted to vectorise the code to make it faster, e.g., instead of operating on the transposed grid in a for-loop, create a new array with all possible transposed grids, then operate on all grids at once.

This is definitely feasible, but it seems to provide only marginal gains; compared the `timeit` tests for `make_Jacobian` and `make_flux`, both only saw ~15% improvement in time (_2.9s vs 3.4s_ & _3.2s vs 3.8s_).

Given that it is technically feasible to vectorise the entire code base, the cost in time and effort outweighs the benefits. Furthermore, a M1 MacBook Pro is able to run the 2D Lax-Liu tests with N=256^2 in 10-15min. Only the Kelvin-Helmholtz instability test requires the longest time (order of hours). So the situation is not that dire.